### PR TITLE
Add base structure of the game state

### DIFF
--- a/src/entities/desk.rs
+++ b/src/entities/desk.rs
@@ -1,0 +1,25 @@
+use ggez::graphics::*;
+use ggez::*;
+
+use crate::Position;
+
+const DESK_HEIGHT: f32 = 70.0;
+const DESK_WIDTH: f32 = 150.0;
+pub struct Desk {
+    pub position: Position,
+}
+
+impl Desk {
+    pub fn draw(&mut self, ctx: &mut Context) -> GameResult {
+        let rect = graphics::Rect::new(self.position.x, self.position.y, DESK_WIDTH, DESK_HEIGHT);
+
+        let rect_mesh =
+            graphics::Mesh::new_rectangle(ctx, DrawMode::fill(), rect, graphics::Color::WHITE)?;
+
+        graphics::draw(ctx, &rect_mesh, DrawParam::default())?;
+
+        graphics::present(ctx)?;
+
+        Ok(())
+    }
+}

--- a/src/entities/map.rs
+++ b/src/entities/map.rs
@@ -1,0 +1,39 @@
+use crate::Position;
+
+use super::desk::*;
+use super::player::*;
+use ggez::*;
+pub struct Map {
+    player: Player,
+    desks: Vec<Desk>,
+}
+
+impl Map {
+    // Creates a new map, with the inital positions of its objects (could be on each objects' ::new)
+    pub fn new() -> Self {
+        let mut initial_desks = Vec::new();
+        let first_desk = Desk {
+            position: Position { x: 200.0, y: 200.0 },
+        };
+        initial_desks.push(first_desk);
+
+        Map {
+            player: Player::new(),
+            desks: initial_desks,
+        }
+    }
+
+    pub fn update(&mut self, ctx: &mut Context) -> GameResult {
+        Ok(())
+    }
+    pub fn draw(&mut self, ctx: &mut Context) -> GameResult {
+        graphics::clear(ctx, graphics::Color::BLACK);
+
+        // We iterate over each desk in the map and tell them to draw themselves
+        for desk in self.desks.iter_mut() {
+            desk.draw(ctx)?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/entities/player.rs
+++ b/src/entities/player.rs
@@ -1,0 +1,7 @@
+pub struct Player {}
+
+impl Player {
+    pub fn new() -> Self {
+        Player {}
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,30 +1,49 @@
 use ggez::*;
+pub mod entities {
+    pub mod desk;
+    pub mod map;
+    pub mod player;
+}
 
+use entities::map::*;
+
+// Position of the elements in the screen, this will be used by all entities
+pub struct Position {
+    x: f32,
+    y: f32,
+}
+
+// The main game state
 struct State {
-    dt: std::time::Duration,
+    map: Map,
+}
+
+impl State {
+    pub fn new() -> Self {
+        State { map: Map::new() }
+    }
 }
 
 impl ggez::event::EventHandler<GameError> for State {
     fn update(&mut self, ctx: &mut Context) -> GameResult {
-        self.dt = timer::delta(ctx);
         Ok(())
     }
     fn draw(&mut self, ctx: &mut Context) -> GameResult {
-        println!("Hello ggez! dt = {}ns", self.dt.as_nanos());
+        self.map.draw(ctx)?;
         Ok(())
     }
 }
 
-pub fn main() {
-    let state = State {
-        dt: std::time::Duration::new(0, 0),
-    };
-
+fn main() -> GameResult {
     let c = conf::Conf::new();
-    let (ctx, event_loop) = ContextBuilder::new("hello_ggez", "awesome_person")
+
+    let (ctx, event_loop) = ContextBuilder::new("wye_2D", "rust_team")
         .default_conf(c)
         .build()
         .unwrap();
 
+    graphics::set_window_title(&ctx, "Welcome to Wyeworks!");
+
+    let state = State::new();
     event::run(ctx, event_loop, state);
 }


### PR DESCRIPTION
### Description

In this PR:

 - Added the basic structure of the game state, including the world map, player, and a list of desks. 
 
Obs:

The interface is cleared and re-drawn on every frame, we're calling `self.map.draw(ctx)` every time the draw function is executed. This means that these methods are used for both the initial drawings of the elements and the drawing of the elements once the context (position, state of the objects) changes. 

Currently, this means that although the position of the desks hasn't changed (and actually won't change), they will be re-drawn every time. 

There is some old debate about only re-drawing what has actually changes, but as we say:

> Premature optimization is the root of all evil

So perhaps we could optimize this later on. (most modern games don't do it anyways)

### Screenshots
![image](https://user-images.githubusercontent.com/22042418/141143271-d7260088-33fe-42f8-b19b-9182c7eb0e3c.png)


