### PR TITLE
Cleanup module declaration and imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /target
 /.vscode
-/docs

--- a/docs/camera_system.drawio
+++ b/docs/camera_system.drawio
@@ -1,0 +1,76 @@
+<mxfile host="65bd71144e">
+    <diagram id="ncp3lcxw3w1cd1IU2U_P" name="Page-1">
+        <mxGraphModel dx="674" dy="378" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="3" value="" style="whiteSpace=wrap;html=1;" parent="1" vertex="1">
+                    <mxGeometry x="170" y="100" width="360" height="320" as="geometry"/>
+                </mxCell>
+                <mxCell id="2" value="World&lt;br&gt;" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="1" vertex="1">
+                    <mxGeometry x="180" y="110" width="50" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="9" style="edgeStyle=none;html=1;entryX=-0.027;entryY=0.658;entryDx=0;entryDy=0;entryPerimeter=0;startArrow=classic;startFill=1;endArrow=none;endFill=0;" parent="1" source="4" target="6" edge="1">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="4" value="" style="whiteSpace=wrap;html=1;fillColor=none;" parent="1" vertex="1">
+                    <mxGeometry x="180" y="240" width="160" height="120" as="geometry"/>
+                </mxCell>
+                <mxCell id="5" value="Camera (180, 600)" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="1" vertex="1">
+                    <mxGeometry x="200" y="210" width="120" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="6" value="Draw()" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="1" vertex="1">
+                    <mxGeometry x="610" y="260" width="50" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="13" value="" style="whiteSpace=wrap;html=1;dashed=1;" parent="1" vertex="1">
+                    <mxGeometry x="590" y="70" width="130" height="130" as="geometry"/>
+                </mxCell>
+                <mxCell id="14" value="struct Camera {&lt;br&gt;size,&lt;br&gt;position&lt;br&gt;}" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="1" vertex="1">
+                    <mxGeometry x="605" y="105" width="100" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="15" value="" style="shape=waypoint;sketch=0;size=6;pointerEvents=1;points=[];fillColor=#d5e8d4;resizable=0;rotatable=0;perimeter=centerPerimeter;snapToPoint=1;strokeColor=#82b366;" parent="1" vertex="1">
+                    <mxGeometry x="240" y="280" width="40" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="16" value="pos en world:&amp;nbsp; 200, 600" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="1" vertex="1">
+                    <mxGeometry x="560" y="340" width="140" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="17" value="pos en screen (sx, sy): 170, 150" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="1" vertex="1">
+                    <mxGeometry x="560" y="520" width="190" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="18" value="ObjX - (cx - cw / 2) = sx" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="1" vertex="1">
+                    <mxGeometry x="565" y="380" width="140" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="19" value="200 - (&lt;b&gt;180 - 150)&lt;/b&gt;&amp;nbsp;=&amp;nbsp; 170" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="1" vertex="1">
+                    <mxGeometry x="565" y="420" width="140" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="20" value="ObjY - (cy - ch / 2) = sy&amp;nbsp;" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="1" vertex="1">
+                    <mxGeometry x="565" y="450" width="140" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="21" value="600 - (&lt;b&gt;600&amp;nbsp; - 150 )&amp;nbsp;&lt;/b&gt; = 150" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="1" vertex="1">
+                    <mxGeometry x="565" y="490" width="150" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="23" value="" style="shape=waypoint;sketch=0;size=6;pointerEvents=1;points=[];fillColor=#d80073;resizable=0;rotatable=0;perimeter=centerPerimeter;snapToPoint=1;strokeColor=#A50040;fontColor=#ffffff;" parent="1" vertex="1">
+                    <mxGeometry x="230" y="280" width="40" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="24" value="300" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="1" vertex="1">
+                    <mxGeometry x="230" y="370" width="40" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="25" value="300" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;rotation=-90;" parent="1" vertex="1">
+                    <mxGeometry x="340" y="320" width="40" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="27" value="" style="shape=waypoint;sketch=0;size=6;pointerEvents=1;points=[];fillColor=#d5e8d4;resizable=0;rotatable=0;perimeter=centerPerimeter;snapToPoint=1;strokeColor=#82b366;" parent="1" vertex="1">
+                    <mxGeometry x="540" y="330" width="40" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="28" value="" style="shape=waypoint;sketch=0;size=6;pointerEvents=1;points=[];fillColor=#d5e8d4;resizable=0;rotatable=0;perimeter=centerPerimeter;snapToPoint=1;strokeColor=#82b366;" parent="1" vertex="1">
+                    <mxGeometry x="540" y="510" width="40" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="29" value="1_000" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="1" vertex="1">
+                    <mxGeometry x="470" y="430" width="50" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="30" value="1_000" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;rotation=-90;" parent="1" vertex="1">
+                    <mxGeometry x="530" y="220" width="50" height="20" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>

--- a/docs/sprites.drawio
+++ b/docs/sprites.drawio
@@ -1,0 +1,67 @@
+<mxfile host="65bd71144e">
+    <diagram id="CBjhklYpDrhJx7aeajbG" name="Page-1">
+        <mxGraphModel dx="882" dy="562" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="29" style="edgeStyle=none;html=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;fontSize=12;endArrow=none;endFill=0;exitX=0.25;exitY=1;exitDx=0;exitDy=0;" edge="1" parent="1" source="2" target="28">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="2" value="Sprite Batch&amp;nbsp;&lt;font style=&quot;font-size: 12px&quot;&gt;(ggez)&lt;/font&gt;" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=22;" vertex="1" parent="1">
+                    <mxGeometry x="95" y="530" width="165" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="26" value="" style="edgeStyle=none;html=1;fontSize=12;endArrow=none;endFill=0;exitX=0.25;exitY=1;exitDx=0;exitDy=0;" edge="1" parent="1" source="3" target="25">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="3" value="Atlas&amp;nbsp;&lt;font style=&quot;font-size: 12px&quot;&gt;(atlas.rs)&lt;/font&gt;" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=22;" vertex="1" parent="1">
+                    <mxGeometry x="490" y="290" width="110" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="11" value="" style="edgeStyle=none;html=1;fontSize=14;endArrow=none;endFill=0;exitX=0.25;exitY=1;exitDx=0;exitDy=0;" edge="1" parent="1" source="4" target="9">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="4" value="PlayerSprite&amp;nbsp;&lt;font style=&quot;font-size: 12px&quot;&gt;(player_sprite.rs)&lt;/font&gt;" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=22;" vertex="1" parent="1">
+                    <mxGeometry x="490" y="550" width="320" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="7" value="where images live in memory" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=14;fontStyle=2" vertex="1" parent="1">
+                    <mxGeometry x="190" y="580" width="130" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="9" value="struct:&lt;br&gt;- idle_sprites&lt;br&gt;&lt;div&gt;&lt;span&gt;- walking_sprites&lt;/span&gt;&lt;/div&gt;" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=14;" vertex="1" parent="1">
+                    <mxGeometry x="520" y="700" width="110" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="12" value="provides functions to draw a sprite into a given batch&amp;nbsp;" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=14;fontStyle=2" vertex="1" parent="1">
+                    <mxGeometry x="690" y="670" width="110" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="22" value="" style="edgeStyle=none;html=1;fontSize=14;endArrow=none;endFill=0;exitX=0.25;exitY=1;exitDx=0;exitDy=0;" edge="1" parent="1" source="17" target="21">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="17" value="&lt;font style=&quot;font-size: 22px&quot;&gt;Sprite&amp;nbsp;&lt;/font&gt;&lt;font style=&quot;font-size: 12px&quot;&gt;(ggez)&lt;/font&gt;" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=22;" vertex="1" parent="1">
+                    <mxGeometry x="107.5" y="290" width="140" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="21" value="struct:&lt;br&gt;- rectangle&lt;br&gt;&lt;div&gt;&lt;span&gt;- scale&lt;/span&gt;&lt;/div&gt;" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=14;" vertex="1" parent="1">
+                    <mxGeometry x="90" y="390" width="110" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="25" value="&lt;div style=&quot;text-align: left&quot;&gt;&lt;span&gt;struct:&lt;/span&gt;&lt;/div&gt;&lt;div style=&quot;text-align: left&quot;&gt;&lt;span&gt;- filename&lt;/span&gt;&lt;/div&gt;&lt;div style=&quot;text-align: left&quot;&gt;&lt;span&gt;- frame&lt;/span&gt;&lt;/div&gt;" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=12;" vertex="1" parent="1">
+                    <mxGeometry x="460" y="380" width="110" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="28" value="struct:&lt;br&gt;- image&lt;br&gt;- draw_params&lt;br&gt;&lt;div&gt;&lt;span&gt;- blend_mode&lt;/span&gt;&lt;/div&gt;" style="text;html=1;strokeColor=none;fillColor=none;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=14;" vertex="1" parent="1">
+                    <mxGeometry x="80" y="660" width="110" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="30" value="a &quot;map&quot;, the loaded json file that tells us how to read the image" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=14;fontStyle=2" vertex="1" parent="1">
+                    <mxGeometry x="600" y="330" width="155" height="90" as="geometry"/>
+                </mxCell>
+                <mxCell id="31" value="struct that stores organized sprites" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=14;fontStyle=2" vertex="1" parent="1">
+                    <mxGeometry x="680" y="610" width="110" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="36" style="edgeStyle=none;html=1;fontSize=12;endArrow=classicThin;endFill=1;" edge="1" parent="1" source="34" target="35">
+                    <mxGeometry relative="1" as="geometry"/>
+                </mxCell>
+                <mxCell id="34" value="&lt;ol&gt;&lt;li&gt;Load player image in memory&lt;/li&gt;&lt;li&gt;Load mapping of sprites in the image&lt;/li&gt;&lt;li&gt;Draw sprites&lt;/li&gt;&lt;/ol&gt;" style="text;html=1;align=left;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=12;" vertex="1" parent="1">
+                    <mxGeometry x="40" y="925" width="250" height="90" as="geometry"/>
+                </mxCell>
+                <mxCell id="35" value="&lt;ol&gt;&lt;li&gt;&lt;span&gt;Create player Sprite Batch&lt;/span&gt;&lt;/li&gt;&lt;li&gt;&lt;span&gt;Create PlayerSprite&lt;br&gt;- create atlas&lt;/span&gt;&lt;/li&gt;&lt;li&gt;Draw sprites&lt;br&gt;- call PlayerSprite.draw with our requirements&lt;/li&gt;&lt;/ol&gt;" style="text;html=1;align=left;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=12;" vertex="1" parent="1">
+                    <mxGeometry x="480" y="910" width="300" height="120" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>

--- a/src/ecs/atlas.rs
+++ b/src/ecs/atlas.rs
@@ -1,7 +1,11 @@
-use ggez::{Context, graphics::{self, spritebatch::SpriteBatch}};
+use crate::ecs::sprites::sprite::Sprite;
+
 use std::path::Path;
 
-use super::sprites::sprite::Sprite;
+use ggez::{
+    graphics::{self, spritebatch::SpriteBatch},
+    Context,
+};
 
 #[derive(Deserialize, Debug)]
 struct Meta {

--- a/src/ecs/components/mod.rs
+++ b/src/ecs/components/mod.rs
@@ -1,0 +1,1 @@
+pub mod npc;

--- a/src/ecs/mod.rs
+++ b/src/ecs/mod.rs
@@ -1,0 +1,6 @@
+pub mod atlas;
+pub mod components;
+pub mod game_state;
+pub mod sprites;
+pub mod systems;
+pub mod utils;

--- a/src/ecs/sprites/mod.rs
+++ b/src/ecs/sprites/mod.rs
@@ -1,0 +1,4 @@
+pub mod npc_sprite;
+pub mod player_sprite;
+pub mod sprite;
+pub mod tile_sprite;

--- a/src/ecs/sprites/npc_sprite.rs
+++ b/src/ecs/sprites/npc_sprite.rs
@@ -1,41 +1,32 @@
+use crate::ecs::{
+    atlas::Atlas,
+    components::npc::Npc,
+    sprites::sprite::Sprite,
+    systems::{physics_system::physics::*, render_system::camera::Camera},
+    utils::constants::NPC_COUNT,
+};
+
 use ggez::{
     graphics::spritebatch::SpriteBatch,
     mint::{Point2, Vector2},
 };
-use super::super::atlas;
-use super::{
-    super::systems::{
-        physics_system::physics::*, render_system::camera::Camera,
-    },
-    sprite::Sprite,
-};
-use super::super::components::npc::Npc;
-use super::super::utils::constants::NPC_COUNT;
 
 pub struct NpcSprite {
     pub sprites: Vec<Sprite>,
 }
 
 impl NpcSprite {
-    pub fn new(atlas: &atlas::Atlas) -> Self {
+    pub fn new(atlas: &Atlas) -> Self {
         let mut sprites = Vec::new();
 
         for npc_count in 0..NPC_COUNT {
             sprites.push(atlas.create_sprite(&format!("npc_{}", npc_count).to_string()));
         }
 
-        Self {
-            sprites,
-        }
+        Self { sprites }
     }
 
-    pub fn draw(
-        &mut self,
-        batch: &mut SpriteBatch,
-        camera: &Camera,
-        physics: &Physics,
-        npc: &Npc,
-    ) {
+    pub fn draw(&mut self, batch: &mut SpriteBatch, camera: &Camera, physics: &Physics, npc: &Npc) {
         let s: &mut Sprite = &mut self.sprites[npc.id as usize];
         let position = camera.world_to_screen(&physics.position);
 

--- a/src/ecs/sprites/player_sprite.rs
+++ b/src/ecs/sprites/player_sprite.rs
@@ -1,16 +1,15 @@
-use ggez::{
-    graphics::spritebatch::SpriteBatch,
-    mint::{Point2, Vector2},
+use crate::ecs::{
+    atlas::Atlas,
+    sprites::sprite::Sprite,
+    systems::{physics_system::physics::*, render_system::camera::Camera},
 };
+
 use std::collections::HashMap;
 use strum::IntoEnumIterator;
 
-use super::super::atlas;
-use super::{
-    super::systems::{
-        physics_system::physics::*, render_system::camera::Camera,
-    },
-    sprite::Sprite,
+use ggez::{
+    graphics::spritebatch::SpriteBatch,
+    mint::{Point2, Vector2},
 };
 
 pub struct PlayerSprite {
@@ -20,14 +19,16 @@ pub struct PlayerSprite {
 }
 
 impl PlayerSprite {
-    pub fn new(atlas: &atlas::Atlas) -> Self {
+    pub fn new(atlas: &Atlas) -> Self {
         let mut idle_sprites = HashMap::new();
         let mut walking_sprites = HashMap::new();
 
         for direction in Direction::iter() {
             idle_sprites.insert(
                 direction,
-                atlas.create_sprite(&format!("player-idle-{}", Direction::to_index(direction)).to_string()),
+                atlas.create_sprite(
+                    &format!("player-idle-{}", Direction::to_index(direction)).to_string(),
+                ),
             );
         }
 

--- a/src/ecs/sprites/sprite.rs
+++ b/src/ecs/sprites/sprite.rs
@@ -1,5 +1,7 @@
-use ggez::{graphics, mint::{Point2, Vector2}};
-
+use ggez::{
+    graphics,
+    mint::{Point2, Vector2},
+};
 
 #[derive(Clone, Debug)]
 pub struct Sprite {

--- a/src/ecs/sprites/tile_sprite.rs
+++ b/src/ecs/sprites/tile_sprite.rs
@@ -1,14 +1,15 @@
+use crate::ecs::{
+    atlas::Atlas,
+    sprites::sprite::Sprite,
+    systems::{physics_system::physics::Position, render_system::camera::Camera},
+    utils::constants::{INTIAL_WORLD_H, INTIAL_WORLD_W},
+};
+
 use ggez::{
     graphics::spritebatch::SpriteBatch,
     mint::{Point2, Vector2},
 };
 
-use super::super::atlas;
-use super::{
-    super::systems::{physics_system::physics::Position, render_system::camera::Camera},
-    super::utils::constants::{INTIAL_WORLD_H, INTIAL_WORLD_W},
-    sprite::Sprite,
-};
 pub const NUMBER_OF_TILES: u8 = 3;
 pub struct TileSprite {
     pub sprite: Sprite,
@@ -49,7 +50,7 @@ fn create_tile(sprite: Sprite, x: f32, y: f32) -> Box<TileSprite> {
     Box::new(tile)
 }
 
-pub fn create_tiles(sprites: &atlas::Atlas) -> Vec<Box<TileSprite>> {
+pub fn create_tiles(sprites: &Atlas) -> Vec<Box<TileSprite>> {
     let floor_tile = sprites.create_sprite("floor_tile.png");
     let width = floor_tile.width;
     let height = floor_tile.height;

--- a/src/ecs/systems/input_system/mod.rs
+++ b/src/ecs/systems/input_system/mod.rs
@@ -1,9 +1,9 @@
-use ggez::*;
-use ggez::{event::KeyCode, input::keyboard};
+pub mod interaction;
+use interaction::Interaction;
 
-use crate::ecs::{
-    game_state::GameState, systems::input_system::interaction::Interaction,
-};
+use ggez::{event::KeyCode, input::keyboard, *};
+
+use crate::ecs::game_state::GameState;
 
 pub fn player_movements(ctx: &mut Context) -> Vec<KeyCode> {
     let player_mov_keys = [KeyCode::Up, KeyCode::Down, KeyCode::Left, KeyCode::Right];

--- a/src/ecs/systems/mod.rs
+++ b/src/ecs/systems/mod.rs
@@ -1,0 +1,3 @@
+pub mod input_system;
+pub mod physics_system;
+pub mod render_system;

--- a/src/ecs/systems/physics_system/mod.rs
+++ b/src/ecs/systems/physics_system/mod.rs
@@ -1,5 +1,7 @@
-use super::physics::*;
-use crate::ecs::{utils::constants::*};
+pub mod physics;
+use physics::*;
+
+use crate::ecs::utils::constants::*;
 use ggez::{event::KeyCode, graphics, Context};
 use rand::Rng;
 
@@ -15,7 +17,7 @@ pub fn initial_player_physics() -> Physics {
         color: graphics::Color::from_rgb(0, 171, 169),
         direction: Some(Direction::Down),
         walking: false,
-        current_focus: None
+        current_focus: None,
     }
 }
 
@@ -30,7 +32,7 @@ pub fn generate_npc_physics() -> Physics {
         color: graphics::Color::from_rgb(112, 111, 211),
         direction: None,
         walking: false,
-        current_focus: None
+        current_focus: None,
     }
 }
 
@@ -87,12 +89,11 @@ pub fn update_player_physics(
             new_player_physics = new_potential_player_physics;
         }
     }
-    
+
     new_player_physics
 }
 
 fn objects_collide(a: &Physics, b: &Physics) -> bool {
-
     let collision = a.position.x - a.size.w_half() < b.position.x + b.size.w_half()
         && a.position.x + a.size.w_half() > b.position.x - b.size.w_half()
         && a.position.y - a.size.h_half() < b.position.y + b.size.h_half()

--- a/src/ecs/systems/physics_system/physics.rs
+++ b/src/ecs/systems/physics_system/physics.rs
@@ -29,7 +29,7 @@ impl Physics {
             color,
             direction,
             walking: false,
-            current_focus
+            current_focus,
         }
     }
 

--- a/src/ecs/systems/render_system/camera.rs
+++ b/src/ecs/systems/render_system/camera.rs
@@ -1,6 +1,11 @@
-use ggez::{Context};
-use super::super::physics_system::physics::{Physics, Position, Size, Direction};
-use super::super::super::utils::constants::{DEFAULT_CAMERA_W, DEFAULT_CAMERA_H, DEFAULT_CAMERA_SPEED, DEFAULT_CAMERA_OFFSET};
+use crate::ecs::{
+    systems::physics_system::physics::{Direction, Physics, Position, Size},
+    utils::constants::{
+        DEFAULT_CAMERA_H, DEFAULT_CAMERA_OFFSET, DEFAULT_CAMERA_SPEED, DEFAULT_CAMERA_W,
+    },
+};
+
+use ggez::Context;
 
 #[derive(Copy, Clone)]
 pub struct Camera {
@@ -34,14 +39,11 @@ impl Camera {
             Direction::Up => self.position.y -= self.speed * dt,
             Direction::Down => self.position.y += self.speed * dt,
             Direction::Left => self.position.x -= self.speed * dt,
-            Direction::Right => self.position.x += self.speed * dt
+            Direction::Right => self.position.x += self.speed * dt,
         }
     }
 
-    pub fn is_player_approaching_camera_edge(
-        &self,
-        player_physics: &Physics
-    ) -> bool {
+    pub fn is_player_approaching_camera_edge(&self, player_physics: &Physics) -> bool {
         let player_camera_position = self.world_to_screen(&player_physics.position);
         let camera_w_third = self.size.width / 3.0;
         let camera_h_third = self.size.height / 3.0;
@@ -51,10 +53,14 @@ impl Camera {
         let bottom_boundry = self.size.height - camera_h_third;
         let right_boundry = self.size.width - camera_h_third;
 
-        return (player_camera_position.x < left_boundry && player_physics.direction == Some(Direction::Left))
-            || (player_camera_position.y < top_boundry && player_physics.direction == Some(Direction::Up))
-            || (player_camera_position.x > right_boundry && player_physics.direction == Some(Direction::Right))
-            || (player_camera_position.y > bottom_boundry && player_physics.direction == Some(Direction::Down));
+        return (player_camera_position.x < left_boundry
+            && player_physics.direction == Some(Direction::Left))
+            || (player_camera_position.y < top_boundry
+                && player_physics.direction == Some(Direction::Up))
+            || (player_camera_position.x > right_boundry
+                && player_physics.direction == Some(Direction::Right))
+            || (player_camera_position.y > bottom_boundry
+                && player_physics.direction == Some(Direction::Down));
     }
 
     pub fn is_within_world_bounds(&self, world_size: &Size, direction: Direction) -> bool {
@@ -78,7 +84,7 @@ impl Camera {
     pub fn maybe_update(&mut self, ctx: &mut Context, player_physics: &Physics, world_size: &Size) {
         let should_update_camera = self.is_player_approaching_camera_edge(player_physics)
             && self.is_within_world_bounds(world_size, player_physics.direction.unwrap());
-    
+
         if should_update_camera {
             self.update_position(player_physics.direction.unwrap(), ctx);
         }

--- a/src/ecs/systems/render_system/mod.rs
+++ b/src/ecs/systems/render_system/mod.rs
@@ -1,20 +1,28 @@
-use super::super::{
-    input_system::interaction::*, physics_system::physics::*, render_system::camera::Camera,
-};
-use super::super::super::utils::constants::NPC_COUNT;
+pub mod camera;
+use camera::Camera;
+
 use crate::ecs::{
     components::npc::Npc,
     game_state::EntityIndex,
-    sprites::{player_sprite::PlayerSprite, tile_sprite::TileSprite, npc_sprite::NpcSprite},
+    sprites::{npc_sprite::NpcSprite, player_sprite::PlayerSprite, tile_sprite::TileSprite},
+    systems::input_system::interaction::Interaction,
+    systems::physics_system::physics::*,
+    utils::constants::NPC_COUNT,
 };
-use ggez::{*, self, Context, GameResult, graphics::{Color, DrawMode, DrawParam, Rect, StrokeOptions, TextFragment, spritebatch::SpriteBatch}};
+use ggez::{
+    self,
+    graphics::{
+        spritebatch::SpriteBatch, Color, DrawMode, DrawParam, Rect, StrokeOptions, TextFragment,
+    },
+    Context, GameResult, *,
+};
 
 pub fn draw_tiles(
     ctx: &mut Context,
     camera: &Camera,
     tiles: &mut Vec<Box<TileSprite>>,
     world_sprite_batch: &mut SpriteBatch,
-    draw_param: graphics::DrawParam
+    draw_param: graphics::DrawParam,
 ) -> GameResult {
     for i in 0..tiles.len() {
         tiles[i].draw(world_sprite_batch, camera);
@@ -57,10 +65,10 @@ pub fn draw_player(
     player_sprite_batch: &mut SpriteBatch,
     player_sprite: &mut PlayerSprite,
     frames: usize,
-    draw_param: graphics::DrawParam
+    draw_param: graphics::DrawParam,
 ) -> GameResult {
     player_sprite.draw(player_sprite_batch, camera, player_physics, frames);
-    
+
     graphics::draw(ctx, player_sprite_batch, draw_param)?;
     player_sprite_batch.clear();
 
@@ -68,30 +76,34 @@ pub fn draw_player(
 }
 
 pub fn draw_npcs(
-    ctx: &mut Context, 
-    camera: &Camera, 
+    ctx: &mut Context,
+    camera: &Camera,
     physics_components: &Vec<Option<Physics>>,
     npcs_components: &Vec<Option<Npc>>,
     npcs_sprite_batch: &mut SpriteBatch,
     npcs_sprite: &mut NpcSprite,
-    draw_param: graphics::DrawParam
+    draw_param: graphics::DrawParam,
 ) -> GameResult {
     for npc_count in 0..NPC_COUNT {
         npcs_sprite.draw(
-            npcs_sprite_batch, camera, 
-            &physics_components[npc_count as usize].unwrap(), 
-            &npcs_components[npc_count as usize].as_ref().unwrap()
+            npcs_sprite_batch,
+            camera,
+            &physics_components[npc_count as usize].unwrap(),
+            &npcs_components[npc_count as usize].as_ref().unwrap(),
         );
     }
-    
-    
+
     graphics::draw(ctx, npcs_sprite_batch, draw_param)?;
     npcs_sprite_batch.clear();
-    
+
     Ok(())
 }
 
-pub fn draw_objects(ctx: &mut Context, camera: &Camera, physics_components: &Vec<Option<Physics>>) -> GameResult {
+pub fn draw_objects(
+    ctx: &mut Context,
+    camera: &Camera,
+    physics_components: &Vec<Option<Physics>>,
+) -> GameResult {
     for object in physics_components {
         match object {
             Some(physics) => draw_object(ctx, &physics, camera)?,
@@ -123,7 +135,7 @@ pub fn draw_interactions(
     camera_size: &Size,
     npcs_components: &Vec<Option<Npc>>,
     current_interaction: &Option<Interaction>,
-    interacting_with: &Option<EntityIndex>
+    interacting_with: &Option<EntityIndex>,
 ) -> GameResult {
     match current_interaction {
         Some(interaction) => {

--- a/src/ecs/utils/constants.rs
+++ b/src/ecs/utils/constants.rs
@@ -1,4 +1,4 @@
-use super::super::systems::physics_system::physics::Position;
+use crate::ecs::systems::physics_system::physics::Position;
 
 pub const HUMANOID_W: f32 = 30.0;
 pub const HUMANOID_H: f32 = 60.0;

--- a/src/ecs/utils/mod.rs
+++ b/src/ecs/utils/mod.rs
@@ -1,0 +1,2 @@
+pub mod constants;
+pub mod npcs_json_loader;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,48 +3,14 @@ extern crate serde_derive;
 extern crate serde;
 extern crate serde_json;
 
+pub mod ecs;
 use ecs::{
     game_state::GameState,
     utils::constants::{DEFAULT_WINDOW_H, DEFAULT_WINDOW_W},
 };
+
 use ggez::conf::FullscreenType;
 use ggez::*;
-
-pub mod ecs {
-    pub mod components {
-        pub mod npc;
-    }
-    pub mod sprites {
-        pub mod npc_sprite;
-        pub mod player_sprite;
-        pub mod sprite;
-        pub mod tile_sprite;
-    }
-
-    pub mod systems {
-        pub mod input_system {
-            pub mod input_system;
-            pub mod interaction;
-        }
-
-        pub mod physics_system {
-            pub mod physics;
-            pub mod physics_system;
-        }
-        pub mod render_system {
-            pub mod camera;
-            pub mod render_system;
-        }
-    }
-
-    pub mod utils {
-        pub mod constants;
-        pub mod npcs_json_loader;
-    }
-
-    pub mod atlas;
-    pub mod game_state;
-}
 
 fn main() -> GameResult {
     let c = conf::Conf::new();


### PR DESCRIPTION
#### What it does

Defines a uniform way to import modules, switches those messy `use super::super::super::super...` into always going to the root:
````
use crate::ecs::{
    systems::{...} 
}
````

Delegates the submodule declaration to each module, we used to have all modules declared in `main.rs`
    
I took a very opinionated decision here, so let me know what you think, we could declare the modules and submodules for our current codebase as follows:
    
**Option A**

```rs
     - systems // folder 
       - render_system.rs  // contains main render_system module, and sub-module declarations (`pub mod camera`)
       - physics_system.rs // same as above
       - render_sytem  // folder
           - camera.rs
        - physics_system // folder 
           - physics.rs
        ... etc.
 ```
     
     
**Option B**
      
```rs
    - system
       - render_sytem  // folder
           - mod.rs // contains main render_system module, and sub-module declarations (`pub mod camera`)
           - camera.rs
        - physics_system // folder 
           - mod.rs
           - physics.rs
        ... etc.
```
     
I went for option B, I believe having everything in the same folder makes it clearer and avoids a bunch of scrolling and clicking when navigating graphically through the codebase. It also makes module declaration feel more explicit even if the file also contains code. i.e.: **you know you'll always find the mod declaration in the `mod.rs` file**

![image](https://user-images.githubusercontent.com/22042418/220910885-fa56230a-bd6f-4dac-ad9c-4e924f1d8822.png)


I'd like to also set up a convention when organizing the imports at the top of the file, for the time being, I used:

1. imports from our own crate
2. imports from std
3. imports from ggez
 
 
 
 Unrelated, but also finally ran `cargo fmt` and removed `/docs` from the `.gitignore` file (so you'll see diagrams added)